### PR TITLE
Modified readme to use npm's ability to install unpublished node pack…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Node.js client for the [PactSafe](https://www.pactsafe.com) Activity API. Inte
 ## Installation
 
 ```bash
-$ npm install --save pactsafe-node
+$ npm install --save https://github.com/pactsafe/pactsafe-node.git
 ```
 
 ## Initialization


### PR DESCRIPTION
…ages from public git repos.

Until module gets published it can be installed directly from a public git repo. See this [`npm doc`](https://docs.npmjs.com/cli/install) for more information.